### PR TITLE
27 & 28 - add new bars to page wrappers

### DIFF
--- a/.ddev/docker-compose.solr.yml
+++ b/.ddev/docker-compose.solr.yml
@@ -73,6 +73,8 @@ services:
 
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
+
+    networks: [default, ddev_default]
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
 

--- a/web/themes/gesso/source/02-layouts/header/_header.scss
+++ b/web/themes/gesso/source/02-layouts/header/_header.scss
@@ -6,7 +6,7 @@
   background: gesso-color(background, site);
   border-bottom: 1px solid rgba(gesso-grayscale(stanford-black), 0.3);
   left: 0;
-  position: fixed;
+  position: sticky;
   top: 0;
   width: 100%;
   z-index: gesso-z-index(nav);

--- a/web/themes/gesso/source/02-layouts/site-container/_site-container.scss
+++ b/web/themes/gesso/source/02-layouts/site-container/_site-container.scss
@@ -1,9 +1,7 @@
 // Layout: Site Container
 
 .l-site-container {
-  padding-top: var(--gesso-header-initial-height);
-
   .has-transparent-nav & {
-    padding-top: 0;
+    margin-top: -(--gesso-header-initial-height);
   }
 }

--- a/web/themes/gesso/source/03-components/cookie-banner/cookie-banner.scss
+++ b/web/themes/gesso/source/03-components/cookie-banner/cookie-banner.scss
@@ -3,11 +3,11 @@
 @use '00-config' as *;
 
 .c-cookie-banner {
-  background: rgba(gesso-grayscale(stanford-black), 0.85);
+  background: rgba(gesso-grayscale(stanford-black), 0.9);
   bottom: 0;
   color: gesso-grayscale(white);
   font-size: gesso-font-size(2);
-  padding: gesso-spacing(2) 0;
+  padding: gesso-spacing(3) 0 gesso-spacing(4);
   position: sticky;
 
   a,

--- a/web/themes/gesso/source/05-pages/page-wrappers/default.jsx
+++ b/web/themes/gesso/source/05-pages/page-wrappers/default.jsx
@@ -5,12 +5,14 @@ import parse from 'html-react-parser';
 import SkiplinksTwig from '../../03-components/skiplinks/skiplinks.twig';
 import BreadcrumbTwig from '../../02-layouts/breadcrumb/breadcrumb.twig';
 import ContentTwig from '../../02-layouts/content/content.twig';
+import { AlertBar } from '../../03-components/alert-bar/alert-bar.stories.jsx';
 import { Breadcrumb } from '../../03-components/breadcrumb/breadcrumb.stories.jsx';
 import { BackToTop } from '../../03-components/back-to-top/back-to-top.stories.jsx';
 import { Footer } from '../../02-layouts/footer/footer.stories.jsx';
 import { Subfooter } from '../../02-layouts/subfooter/subfooter.stories';
 import { Header } from '../../02-layouts/header/header.stories';
 import { SocialShare } from '../../03-components/social-share/social-share.stories';
+import { CookieBanner } from '../../03-components/cookie-banner/cookie-banner.stories';
 
 const PageWrapper = props => {
   // eslint-disable-next-line react/prop-types
@@ -19,6 +21,7 @@ const PageWrapper = props => {
   return (
     <div className={bodyClasses}>
       {parse(SkiplinksTwig())}
+      {AlertBar(AlertBar.args)}
       {Header(Header.args)}
       <div className="l-site-container">
         {hero}
@@ -46,6 +49,7 @@ const PageWrapper = props => {
         </main>
         {Footer(Footer.args)}
         {Subfooter(Subfooter.args)}
+        {CookieBanner(CookieBanner.args)}
       </div>
       {BackToTop({
         ...BackToTop.args,


### PR DESCRIPTION
Adds the cookie and alert banners to the storybook page wrapper.

@kmonahan It seemed like the cleanest way to get the top bar behavior from the designs was changing the main header to `position: sticky` and removing the top padding from the site container; I noticed we also have a style for a 'transparent nav' but I don't see that built anywhere yet, so I just tried to estimate what we'd need to change there.
You have more context here than I do - let me know if you see any issues with this solution.