### PR TITLE
208 - minor cleanup in footer social menu

### DIFF
--- a/web/themes/gesso/source/02-layouts/footer/_footer.scss
+++ b/web/themes/gesso/source/02-layouts/footer/_footer.scss
@@ -56,6 +56,7 @@
 
 .l-footer__contact-links {
   @include list-clean;
+  font-size: 15px;
   margin-top: rem(gesso-spacing(2.5));
 
   li {

--- a/web/themes/gesso/source/03-components/social-links/_social-links.scss
+++ b/web/themes/gesso/source/03-components/social-links/_social-links.scss
@@ -4,7 +4,9 @@
 
 .c-social-links {
   @include list-inline;
-  gap: rem(gesso-spacing(2.5));
+  font-size: 16px;
+  gap: rem(gesso-spacing(2));
+  margin-top: 1rem;
 
   a {
     color: inherit;
@@ -33,4 +35,9 @@
 
 .c-social-links__linkedin:hover {
   color: #0a66c2;
+}
+
+// No hover colors in the footer due to low contrast
+.l-footer .c-social-links li:hover {
+  color: gesso-grayscale(white);
 }


### PR DESCRIPTION
The ticket called out the space above the links & wanting to turn off the hover colors in this area; I also adjusted the size to get it closer to designs. Left the hover colors in case they're still needed outside of the footer.

@kmonahan for some reason, [icons](https://integration-slac-w6-d9.pantheonsite.io/themes/gesso/storybook/?path=/story/components-icon--icon) aren't showing up on [integration](https://integration-slac-w6-d9.pantheonsite.io/themes/gesso/storybook/?path=/story/layouts-footer--footer) - they're fine on this branch and it's been merged in, so I'm not sure what's up.