### PR TITLE
91 & 56 - topic & poster FED

### DIFF
--- a/web/themes/gesso/source/00-config/mixins/_link.scss
+++ b/web/themes/gesso/source/00-config/mixins/_link.scss
@@ -40,7 +40,7 @@
         content: '';
         display: inline-block;
         height: 0.75em;
-        margin-left: rem(gesso-spacing(0.5));
+        margin-left: 0.25em;
         margin-top: em(-3px, gesso-base-font-size());
         transition: transform gesso-duration(shortest) ease-out;
         vertical-align: middle;
@@ -53,7 +53,7 @@
     &:active {
       @media (prefers-reduced-motion: no-preference) {
         span::after {
-          transform: translateX(rem(6px));
+          transform: translateX(em(6px, 16px));
         }
       }
     }

--- a/web/themes/gesso/source/03-components/_index.scss
+++ b/web/themes/gesso/source/03-components/_index.scss
@@ -42,6 +42,7 @@
 @use 'menu/menu--subfooter/menu--subfooter';
 @use 'message/message';
 @use 'overlap-image/overlap-image';
+@use 'overlay-link/overlay-link';
 @use 'page-title/page-title';
 @use 'pager/pager';
 @use 'pager/pager--mini/pager--mini';

--- a/web/themes/gesso/source/03-components/kicker/_kicker.scss
+++ b/web/themes/gesso/source/03-components/kicker/_kicker.scss
@@ -3,7 +3,8 @@
 
 @use '00-config' as *;
 
-.c-kicker {
+.c-kicker,
+%c-kicker {
   @include font-family-primary;
   font-size: rem(gesso-font-size(1));
   font-weight: gesso-font-weight(bold);

--- a/web/themes/gesso/source/03-components/overlay-link/_overlay-link.scss
+++ b/web/themes/gesso/source/03-components/overlay-link/_overlay-link.scss
@@ -1,0 +1,64 @@
+// @file
+// Component: c-overlay-link
+@use '00-config' as *;
+
+.c-overlay-link {
+  @include arrow-link(white);
+  display: table;
+  position: relative;
+  z-index: 0;
+
+  img {
+    display: block;
+  }
+
+  span.c-overlay-link__title {
+    white-space: normal;
+  }
+}
+
+.c-overlay-link__content {
+  background: rgba(0, 0, 0, 0.8);
+  color: gesso-grayscale(white);
+  display: flex;
+  flex-direction: column;
+  inset: 0;
+  justify-content: flex-end;
+  opacity: 0;
+  padding: 30px;
+  position: absolute;
+  transition: gesso-duration(standard) opacity;
+  z-index: 2;
+
+  .c-overlay-link:hover &,
+  .c-overlay-link:focus &,
+  .c-overlay-link:active & {
+    opacity: 1;
+  }
+}
+
+.c-overlay-link__title {
+  @include responsive-font-size(7);
+}
+
+.c-overlay-link__label {
+  background: gesso-grayscale(white);
+  bottom: 0;
+  left: 0;
+  padding: 10px 20px;
+  position: absolute;
+}
+
+.c-overlay-link__arrow {
+  @include svg-background(arrow-white);
+  background-repeat: no-repeat;
+  background-size: contain;
+  content: '';
+  display: inline-block;
+  height: 0.75em;
+  margin-left: rem(gesso-spacing(0.5));
+  margin-top: em(-3px, gesso-base-font-size());
+  transition: transform gesso-duration(shortest) ease-out;
+  vertical-align: middle;
+  width: 1em;
+}

--- a/web/themes/gesso/source/03-components/overlay-link/_overlay-link.scss
+++ b/web/themes/gesso/source/03-components/overlay-link/_overlay-link.scss
@@ -3,17 +3,12 @@
 @use '00-config' as *;
 
 .c-overlay-link {
-  @include arrow-link(white);
   display: table;
   position: relative;
   z-index: 0;
 
   img {
     display: block;
-  }
-
-  span.c-overlay-link__title {
-    white-space: normal;
   }
 }
 
@@ -39,6 +34,15 @@
 
 .c-overlay-link__title {
   @include responsive-font-size(7);
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  span::after {
+    transform: none !important;
+  }
 }
 
 .c-overlay-link__label {
@@ -47,18 +51,4 @@
   left: 0;
   padding: 10px 20px;
   position: absolute;
-}
-
-.c-overlay-link__arrow {
-  @include svg-background(arrow-white);
-  background-repeat: no-repeat;
-  background-size: contain;
-  content: '';
-  display: inline-block;
-  height: 0.75em;
-  margin-left: rem(gesso-spacing(0.5));
-  margin-top: em(-3px, gesso-base-font-size());
-  transition: transform gesso-duration(shortest) ease-out;
-  vertical-align: middle;
-  width: 1em;
 }

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
@@ -1,0 +1,55 @@
+import parse from 'html-react-parser';
+
+import twigTemplate from './overlay-link.twig';
+import data from './overlay-link.yml';
+import globalData from '../../00-config/storybook.global-data.yml';
+
+const settings = {
+  title: 'Components/Overlay Link',
+  parameters: {
+    controls: {
+      include: [
+        'modifier_classes',
+        'image',
+        'label',
+        'kicker',
+        'title',
+      ],
+    },
+  },
+};
+
+const OverlayLink = args =>
+  parse(
+    twigTemplate({
+      ...args,
+    })
+  );
+OverlayLink.args = { ...data, ...globalData };
+
+const Poster = args =>
+  parse(
+    twigTemplate({
+      ...args,
+      image: 'https://picsum.photos/390/600?image=237"',
+      label: '',
+      kicker: 'Poster Details',
+      title: 'Arianna Gleason lecture',
+    })
+  );
+Poster.args = { ...data, ...globalData };
+
+const Topic = args =>
+  parse(
+    twigTemplate({
+      ...args,
+      image: 'https://picsum.photos/400/400?image=237"',
+      label: 'Dark Energy',
+      kicker: 'Tagged in',
+      title: 'Dark Energy',
+    })
+  );
+Topic.args = { ...data, ...globalData };
+
+export default settings;
+export { OverlayLink, Poster, Topic };

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
@@ -3,6 +3,7 @@ import parse from 'html-react-parser';
 import twigTemplate from './overlay-link.twig';
 import data from './overlay-link.yml';
 import globalData from '../../00-config/storybook.global-data.yml';
+import '../arrow-link/arrow-link.es6';
 
 const settings = {
   title: 'Components/Overlay Link',

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
@@ -16,7 +16,7 @@
     {% if kicker %}
       {% include '@components/kicker/kicker.twig' with { kicker_content: kicker } %}
     {% endif %}
-    <span class="c-overlay-link__title">
+    <span class="c-arrow-link--white c-overlay-link__title">
       {{ title }}
     </span>
   </div>

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
@@ -1,0 +1,23 @@
+{% set classes = [
+  'c-overlay-link',
+  modifier_classes ? modifier_classes : ''
+] %}
+
+<a {{ add_attributes({ class: classes, href: link } ) }}>
+  <img src="{{ image }}" alt="">
+  {% if label %}
+    {% include '@components/kicker/kicker.twig' with {
+      kicker_content: label,
+      modifier_classes: 'c-overlay-link__label',
+    }
+  %}
+  {% endif %}
+  <div class="c-overlay-link__content">
+    {% if kicker %}
+      {% include '@components/kicker/kicker.twig' with { kicker_content: kicker } %}
+    {% endif %}
+    <span class="c-overlay-link__title">
+      {{ title }}
+    </span>
+  </div>
+</a>

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.yml
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.yml
@@ -1,0 +1,6 @@
+---
+link: '#'
+kicker: 'Tagged in'
+title: 'Dark Energy'
+image: 'https://picsum.photos/600/450?image=237'
+label: 'Dark Energy'


### PR DESCRIPTION
Made one component that both the topic & poster can use for their hover stylings.

I used `arrow-link` but had to turn off the whitespace override to keep the title fitting into the card; we may need to find a different solution for keeping the arrow inline, if that's important to the client.