### PR TITLE
Slac22 94 - topic grid updates

### DIFF
--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.stories.jsx
@@ -32,7 +32,9 @@ const Poster = args =>
   parse(
     twigTemplate({
       ...args,
-      image: 'https://picsum.photos/390/600?image=237"',
+      image: {
+        src: 'https://picsum.photos/390/600?image=237',
+      },
       label: '',
       kicker: 'Poster Details',
       title: 'Arianna Gleason lecture',
@@ -44,7 +46,9 @@ const Topic = args =>
   parse(
     twigTemplate({
       ...args,
-      image: 'https://picsum.photos/400/400?image=237"',
+      image: {
+        src: 'https://picsum.photos/400/400?image=237',
+      },
       label: 'Dark Energy',
       kicker: 'Tagged in',
       title: 'Dark Energy',

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.twig
@@ -4,7 +4,7 @@
 ] %}
 
 <a {{ add_attributes({ class: classes, href: link } ) }}>
-  <img src="{{ image }}" alt="">
+  <img src="{{ image.src }}" alt="" loading="lazy" {{ image.height? ' height=' ~ image.height : '' }} {{ image.width ? ' width=' ~ image.width }}>
   {% if label %}
     {% include '@components/kicker/kicker.twig' with {
       kicker_content: label,

--- a/web/themes/gesso/source/03-components/overlay-link/overlay-link.yml
+++ b/web/themes/gesso/source/03-components/overlay-link/overlay-link.yml
@@ -2,5 +2,8 @@
 link: '#'
 kicker: 'Tagged in'
 title: 'Dark Energy'
-image: 'https://picsum.photos/600/450?image=237'
+image:
+  src: 'https://picsum.photos/600/450?image=237'
+  width: '600'
+  alt: ''
 label: 'Dark Energy'

--- a/web/themes/gesso/source/03-components/topic-grid/topic-grid.yml
+++ b/web/themes/gesso/source/03-components/topic-grid/topic-grid.yml
@@ -14,62 +14,194 @@ research_areas:
     label: 'New Technologies'
 items:
   - title: 'Square'
-    image: 'https://picsum.photos/400/400'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
     link: '#'
     width: 1
     filter: 1
   - title: 'Wide'
-    image: 'https://picsum.photos/800/400'
+    image:
+      src: 'https://picsum.photos/800/400'
+      height: 400
+      width: 800
     link: '#'
     width: 2
     filter: 3
   - title: 'Short'
-    image: 'https://picsum.photos/400/190'
+    image:
+      src: 'https://picsum.photos/400/190?image=666'
+      height: 100
+      width: 400
     link: '#'
     width: 1
     filter: 2
   - title: 'Large Square'
-    image: 'https://picsum.photos/400/400'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
     link: '#'
     width: 1
     filter: 5
   - title: 'Short'
-    image: 'https://picsum.photos/400/190'
+    image:
+      src: 'https://picsum.photos/400/190?image=666'
+      height: 100
+      width: 400
     link: '#'
     width: 1
     filter: 1
   - title: 'One column tall'
-    image: 'https://picsum.photos/400/580'
+    image:
+      src: 'https://picsum.photos/400/580?image=237'
+      height: 580
+      width: 400
     link: '#'
     width: 1
     filter: 3
   - title: 'Square'
-    image: 'https://picsum.photos/400/400'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
     link: '#'
     width: 1
     filter: 2
   - title: 'Wide'
-    image: 'https://picsum.photos/800/400'
+    image:
+      src: 'https://picsum.photos/800/400'
+      height: 400
+      width: 800
     link: '#'
     width: 2
     filter: 4
   - title: 'Square'
-    image: 'https://picsum.photos/400/400'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
     link: '#'
     width: 1
     filter: 5
   - title: 'Short'
-    image: 'https://picsum.photos/400/180'
+    image:
+      src: 'https://picsum.photos/400/180?image=237'
+      height: 100
+      width: 400
     link: '#'
     width: 1
     filter: 2
   - title: 'Wide and short'
-    image: 'https://picsum.photos/800/200'
+    image:
+      src: 'https://picsum.photos/800/200'
+      height: 200
+      width: 800
     link: '#'
     width: 2
     filter: 3
   - title: 'Short'
-    image: 'https://picsum.photos/400/180'
+    image:
+      src: 'https://picsum.photos/400/180'
+      height: 180
+      width: 400
+    link: '#'
+    width: 1
+    filter: 4
+  - title: 'Square'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
+    link: '#'
+    width: 1
+    filter: 1
+  - title: 'Wide'
+    image:
+      src: 'https://picsum.photos/800/400'
+      height: 400
+      width: 800
+    link: '#'
+    width: 2
+    filter: 3
+  - title: 'Short'
+    image:
+      src: 'https://picsum.photos/400/190?image=666'
+      height: 190
+      width: 400
+    link: '#'
+    width: 1
+    filter: 2
+  - title: 'Large Square'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
+    link: '#'
+    width: 1
+    filter: 5
+  - title: 'Short'
+    image:
+      src: 'https://picsum.photos/400/190'
+      height: 190
+      width: 400
+    link: '#'
+    width: 1
+    filter: 1
+  - title: 'One column tall'
+    image:
+      src: 'https://picsum.photos/400/580?image=237'
+      height: 580
+      width: 400
+    link: '#'
+    width: 1
+    filter: 3
+  - title: 'Square'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
+    link: '#'
+    width: 1
+    filter: 2
+  - title: 'Wide'
+    image:
+      src: 'https://picsum.photos/800/400'
+      height: 400
+      width: 800
+    link: '#'
+    width: 2
+    filter: 4
+  - title: 'Square'
+    image:
+      src: 'https://picsum.photos/400/400'
+      height: 400
+      width: 400
+    link: '#'
+    width: 1
+    filter: 5
+  - title: 'Short'
+    image:
+      src: 'https://picsum.photos/400/180?image=237'
+      height: 180
+      width: 400
+    link: '#'
+    width: 1
+    filter: 2
+  - title: 'Wide and short'
+    image:
+      src: 'https://picsum.photos/800/200'
+      height: 200
+      width: 800
+    link: '#'
+    width: 2
+    filter: 3
+  - title: 'Short'
+    image:
+      src: 'https://picsum.photos/400/180'
+      height: 100
+      width: 400
     link: '#'
     width: 1
     filter: 4


### PR DESCRIPTION
Added lazyloading & set images in this grid to use dimensions if possible - this will keep masonry from breaking too much if an image fails to load.
This is the most basic browser-level lazyloading; I think it'll be enough for their purposes but it's been a little tough to realistically test inside of storybook/with placeholder images. I think we'll have a better sense of whether we need more once it's integrated & pulling real images.