### PR TITLE
53 - filter modal visual overflow tweaks

### DIFF
--- a/web/themes/gesso/source/03-components/filter-modal/_filter-modal.scss
+++ b/web/themes/gesso/source/03-components/filter-modal/_filter-modal.scss
@@ -24,6 +24,7 @@
 
 .c-filter-modal__col {
   margin-bottom: 50px;
+  text-indent: 4px; // avoids focus outline cutoffs
 
   &:last-child {
     margin-bottom: 10px;
@@ -106,6 +107,7 @@
     border: 1px solid gesso-grayscale(gray-1);
     height: auto;
     margin: auto;
+    max-height: 100%;
     overflow: auto;
     padding: 60px 120px 20px 60px;
     width: auto;


### PR DESCRIPTION
- slight text-indent to keep focus outlines from cutting off in mobile
- set a height so the container becomes scrollable if content is too tall (for short laptops etc)