### PR TITLE
Slac22-300 - adjust microsite anchor links scroll position

### DIFF
--- a/web/themes/gesso/source/01-global/html-elements/01-html/_html.scss
+++ b/web/themes/gesso/source/01-global/html-elements/01-html/_html.scss
@@ -9,6 +9,7 @@ html {
   font-size: 100% * (math.div(gesso-base-font-size(), 16px));
   line-height: gesso-line-height(base);
   min-height: 100%;
+  scroll-padding-top: var(--gesso-header-current-height, 0);
   text-size-adjust: 100%;
   @media screen and (prefers-reduced-motion: no-preference) {
     scroll-behavior: smooth;

--- a/web/themes/gesso/source/01-global/html-elements/15-inline-elements/_inline-elements.scss
+++ b/web/themes/gesso/source/01-global/html-elements/15-inline-elements/_inline-elements.scss
@@ -52,6 +52,10 @@
       content: '';
     }
   }
+
+  &:empty {
+    display: block; // keeps empty anchors from taking up vertical space, counterintuitively
+  }
 }
 
 address {


### PR DESCRIPTION
- scroll-padding-top keeps anchor targets from hiding behind the header
- inline empty anchors take up 1 line-height, throwing off the scroll position; block ones don't