### PR TITLE
[SLAC22-144] Limit view mode selection on image_embed paragraph edit,…

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.image_carousel.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.image_carousel.default.yml
@@ -24,9 +24,10 @@ content:
       autocollapse: none
       closed_mode_threshold: 0
       add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: ''
+      form_display_mode: carousel
+      default_paragraph_type: image_embed
       features:
+        add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.image_embed.carousel.yml
+++ b/config/sync/core.entity_form_display.paragraph.image_embed.carousel.yml
@@ -1,0 +1,45 @@
+uuid: b18f967c-ee2e-4ccb-9315-4ee0620bac5a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.paragraph.carousel
+    - field.field.paragraph.image_embed.field_boolean
+    - field.field.paragraph.image_embed.field_image
+    - field.field.paragraph.image_embed.field_long_text
+    - field.field.paragraph.image_embed.field_view_mode
+    - paragraphs.paragraphs_type.image_embed
+  module:
+    - media_library
+    - text
+id: paragraph.image_embed.carousel
+targetEntityType: paragraph
+bundle: image_embed
+mode: carousel
+content:
+  field_boolean:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_image:
+    type: media_library_widget
+    weight: 0
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_long_text:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_view_mode: true
+  status: true

--- a/config/sync/core.entity_form_mode.paragraph.carousel.yml
+++ b/config/sync/core.entity_form_mode.paragraph.carousel.yml
@@ -1,0 +1,10 @@
+uuid: 3ccae21f-e885-4c77-bedf-aaa63228879a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.carousel
+label: Carousel
+targetEntityType: paragraph
+cache: true

--- a/config/sync/field.field.paragraph.image_embed.field_view_mode.yml
+++ b/config/sync/field.field.paragraph.image_embed.field_view_mode.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.paragraph.carousel
     - core.entity_view_mode.paragraph.centered
     - core.entity_view_mode.paragraph.centered_wide
     - field.storage.paragraph.field_view_mode
@@ -24,7 +23,6 @@ default_value:
 default_value_callback: ''
 settings:
   allowed_view_modes:
-    carousel: carousel
     centered: centered
     centered_wide: centered_wide
 field_type: view_mode_switch

--- a/web/themes/gesso/includes/paragraph.inc
+++ b/web/themes/gesso/includes/paragraph.inc
@@ -40,11 +40,10 @@ function gesso_preprocess_paragraph__section(&$vars) {
  */
 function gesso_preprocess_paragraph__image_embed(&$vars) {
   $paragraph = $vars['elements']['#paragraph'];
-
   // If a caption override is selected and the override text field is populated,
   // write the override caption into the media entity for templating by the
   // image template.
-  if ($paragraph->field_boolean->value && !empty($vars['content']['field_image'][0])) {
+  if ($paragraph->field_boolean->value && !empty($vars['content']['field_image'][0]['#media'])) {
     // Extract the media entity from the image field. Note that if the view mode
     // being used to render the field is not Rendered Entity then ['#media'] will not
     // be set and the code will error. Only overwrite the media item's caption with
@@ -54,10 +53,10 @@ function gesso_preprocess_paragraph__image_embed(&$vars) {
       // the caption field on the image, otherwise empty the image's caption field,
       // presumably because the editor did not want the image's caption to display.
       if ($paragraph->field_long_text->value) {
-        $media->field_caption = $paragraph->field_long_text;
+        $media->field_caption->value = $paragraph->field_long_text->value;
       }
       else {
-        $media->field_caption = NULL;
+        $media->field_caption->value = NULL;
       }
     }
   }


### PR DESCRIPTION
Updated:

1) Removed option to assign Carousel as a display style in the paragraph edit
2) Fixed caption override logic in includes/paragraph.inc

Tested on integration (https://integration-slac-w6-d9.pantheonsite.io/node/17)