### PR TITLE
315 - fix issue w/external button links

### DIFF
--- a/web/themes/gesso/source/03-components/button/_button.scss
+++ b/web/themes/gesso/source/03-components/button/_button.scss
@@ -214,6 +214,30 @@
       }
     }
   }
+
+  &.c-button--outline-secondary {
+    &::after {
+      filter: none;
+    }
+
+    &:hover,
+    &:focus-visible {
+      &::after {
+        filter: invert(1);
+      }
+    }
+  }
+
+  &.external-link {
+    &::after {
+      display: none;
+    }
+  }
+
+  .c-icon {
+    margin-left: rem(8px);
+    transform: none;
+  }
 }
 
 .c-button--download {


### PR DESCRIPTION
Prevent chevron & external icon from showing at the same time, add a little spacing to the external button icon so the buttons look more consistent, fix a color mismatch in one of the secondary styles.