### PR TITLE
152 - account for page title followed directly by author

### DIFF
--- a/web/themes/gesso/source/03-components/page-title/_page-title.scss
+++ b/web/themes/gesso/source/03-components/page-title/_page-title.scss
@@ -8,6 +8,10 @@
   h1 {
     margin: 0;
   }
+
+  h1 + p {
+    margin-top: 1rem;
+  }
 }
 
 .c-page-title--sidebar .l-constrain {


### PR DESCRIPTION
Keeps things from looking cramped if the lede is empty.
Example: https://integration-slac-w6-d9.pantheonsite.io/node/40