### PR TITLE
407 - keep cookie bar from obscuring footer

### DIFF
--- a/web/themes/gesso/source/03-components/cookie-banner/_cookie-banner.scss
+++ b/web/themes/gesso/source/03-components/cookie-banner/_cookie-banner.scss
@@ -51,6 +51,7 @@
 
 // wrapper class comes from the module
 .sliding-popup-bottom {
+  position: sticky;
   text-align: left;
   width: 100%;
 }


### PR DESCRIPTION
we do lose the slide-down-and-out animation when you're 100% scrolled with this, but that seems acceptable compared to blocking footer logos.