### PR TITLE
474 - larger mobile logo for brand reasons

### DIFF
--- a/web/themes/gesso/source/02-layouts/header/_header.scss
+++ b/web/themes/gesso/source/02-layouts/header/_header.scss
@@ -101,7 +101,7 @@
 
 .l-header__logo {
   display: block;
-  height: min(calc(var(--gesso-header-initial-height) - 48px), 40px);
+  height: 34px;
   width: auto;
 
   .has-inverse-nav & {


### PR DESCRIPTION
The height is eyeballed based off their screenshot; they should probably go back and update this in figma to avoid future confusion.