### PR TITLE
473 - fix cut-off text in alert bar

### DIFF
--- a/web/themes/gesso/source/03-components/alert-bar/alert-bar.scss
+++ b/web/themes/gesso/source/03-components/alert-bar/alert-bar.scss
@@ -10,7 +10,6 @@
   background-color: gesso-brand(cardinal, dark);
   color: gesso-grayscale(white);
   font-size: rem(13px);
-  height: var(--gesso-alert-bar-height);
   padding: gesso-spacing(1) 0;
   width: 100%;
 


### PR DESCRIPTION
As far as I can tell, there's no reason to limit the height on the bar.