### PR TITLE
406 - fix icon path for TOC chevron

### DIFF
--- a/web/themes/gesso/source/03-components/toc/toc.es6.js
+++ b/web/themes/gesso/source/03-components/toc/toc.es6.js
@@ -2,8 +2,9 @@ import Drupal from 'drupal';
 import { BREAKPOINTS } from '../../00-config/_GESSO.es6';
 
 Drupal.behaviors.toc = {
-  attach(context) {
+  attach(context, settings) {
     const tocs = context.querySelectorAll('.c-toc');
+    const imagePath = settings.gesso.gessoImagePath;
     tocs.forEach(toc => {
       const mediaQuery = window.matchMedia(
         `(max-width: ${parseInt(BREAKPOINTS.desktop, 10) - 1}px)`
@@ -23,7 +24,7 @@ Drupal.behaviors.toc = {
           tocButton.setAttribute('role', 'button');
           tocButton.insertAdjacentHTML(
             'beforeend',
-            `<svg class="c-icon c-toc__icon" aria-hidden="true"><use xlink:href="/themes/gesso/dist/images/sprite.artifact.svg#angle-down"></use></svg>`
+            `<svg class="c-icon c-toc__icon" aria-hidden="true"><use xlink:href="${imagePath}/sprite.artifact.svg#angle-down"></use></svg>`
           );
           tocLinks.hidden = true;
           tocLinks.setAttribute('aria-expanded', 'false');

--- a/web/themes/gesso/source/03-components/toc/toc.es6.js
+++ b/web/themes/gesso/source/03-components/toc/toc.es6.js
@@ -23,7 +23,7 @@ Drupal.behaviors.toc = {
           tocButton.setAttribute('role', 'button');
           tocButton.insertAdjacentHTML(
             'beforeend',
-            `<svg class="c-icon c-toc__icon" aria-hidden="true"><use xlink:href="../images/sprite.artifact.svg#angle-down"></use></use> </svg>`
+            `<svg class="c-icon c-toc__icon" aria-hidden="true"><use xlink:href="/themes/gesso/dist/images/sprite.artifact.svg#angle-down"></use></svg>`
           );
           tocLinks.hidden = true;
           tocLinks.setAttribute('aria-expanded', 'false');

--- a/web/themes/gesso/source/03-components/toc/toc.scss
+++ b/web/themes/gesso/source/03-components/toc/toc.scss
@@ -46,6 +46,8 @@
 }
 
 .c-toc__icon {
+  top: 0;
+
   [aria-expanded='true'] & {
     transform: rotate(180deg);
   }


### PR DESCRIPTION
This one was interfering with the usability of the UI, so I'd call it a blocker. Granted - this fix is going to make it disappear in storybook, but at this stage of the project, that seems acceptable.

The css change is just to line it up better visually.