### PR TITLE
[SLAC22] Pin container image for deployments

### DIFF
--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -139,7 +139,7 @@ jobs:
 
   deploy_to_pantheon:
     container:
-      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.0@sha256:15b244fdfeb225541a5eef4801a4abdebd2d4b8146cd472329d75226b10a87e5
+      image: pantheonpublic/build-tools-ci@sha256:15b244fdfeb225541a5eef4801a4abdebd2d4b8146cd472329d75226b10a87e5
       options: --user root
     runs-on: ubuntu-latest
     needs: [configure_env_vars, static_tests, build_gesso]

--- a/.github/workflows/build_deploy_and_test.yml
+++ b/.github/workflows/build_deploy_and_test.yml
@@ -139,7 +139,7 @@ jobs:
 
   deploy_to_pantheon:
     container:
-      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.0
+      image: quay.io/pantheon-public/build-tools-ci:8.x-php8.0@sha256:15b244fdfeb225541a5eef4801a4abdebd2d4b8146cd472329d75226b10a87e5
       options: --user root
     runs-on: ubuntu-latest
     needs: [configure_env_vars, static_tests, build_gesso]


### PR DESCRIPTION
- [SLAC22] Pin deploy image to specific version
- [SLAC22] Use dockerhub SHA'd version instead of quay

After a recent update to the pantheonpublic/build-tools-ci docker image, our builds were failing due to a git error: `fatal: detected dubious ownership in repository at '/__w/W6-D9/W6-D9'`. Reverting to 
the prior container image seems to resolve the issue. I suspect this is due to a change in the underlying image the container is being built from.
