### PR TITLE
SLAC22-583: change event pathauto pattern

### DIFF
--- a/config/sync/pathauto.pattern.events.yml
+++ b/config/sync/pathauto.pattern.events.yml
@@ -7,12 +7,12 @@ dependencies:
 id: events
 label: Events
 type: 'canonical_entities:node'
-pattern: '/events/[node:created:custom:Y]-[node:created:custom:m]-[node:created:custom:d]-[node:title]'
+pattern: '/events/[node:field_datetime_range:start_date:custom:Y]-[node:field_datetime_range:start_date:custom:m]-[node:field_datetime_range:start_date:custom:d]-[node:title]'
 selection_criteria:
-  bbecfee2-1ba1-424a-885e-cb2f8ed214cb:
+  1b8f5c1f-5869-4d14-b9fe-4827fb659bd4:
     id: 'entity_bundle:node'
     negate: false
-    uuid: bbecfee2-1ba1-424a-885e-cb2f8ed214cb
+    uuid: 1b8f5c1f-5869-4d14-b9fe-4827fb659bd4
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
Per https://forumone.atlassian.net/browse/SLAC22-583, updated Event pathauto pattern to use event start date instead of node created date.