### PR TITLE
SLAC22-603: SLAC22-329, config split and GTM configured

### DIFF
--- a/config/splits/local/.htaccess
+++ b/config/splits/local/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/config/splits/prod/.htaccess
+++ b/config/splits/prod/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/config/splits/prod/google_tag.container.main.yml
+++ b/config/splits/prod/google_tag.container.main.yml
@@ -1,0 +1,65 @@
+uuid: c1801187-a5e0-484e-bda9-ddf2e4929d00
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+    - webform
+id: main
+label: Main
+weight: 0
+container_id: GTM-M364PQ8
+data_layer: dataLayer
+include_classes: false
+whitelist_classes: |-
+  google
+  nonGooglePixels
+  nonGoogleScripts
+  nonGoogleIframes
+blacklist_classes: |-
+  customScripts
+  customPixels
+include_environment: false
+environment_id: ''
+environment_token: ''
+path_toggle: 'exclude listed'
+path_list: |-
+  /admin*
+  /batch*
+  /node/add*
+  /node/*/edit
+  /node/*/delete
+  /user/*/edit*
+  /user/*/cancel*
+role_toggle: 'include listed'
+role_list:
+  anonymous: anonymous
+status_toggle: 'exclude listed'
+status_list: |-
+  403
+  404
+conditions:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles: {  }
+  'entity_bundle:taxonomy_term':
+    id: 'entity_bundle:taxonomy_term'
+    negate: false
+    context_mapping:
+      taxonomy_term: '@taxonomy_term.taxonomy_term_route_context:taxonomy_term'
+    bundles: {  }
+  'entity_bundle:webform_submission':
+    id: 'entity_bundle:webform_submission'
+    negate: false
+    context_mapping:
+      webform_submission: '@webform.webform_submission_route_context:webform_submission'
+    bundles: {  }
+  webform:
+    id: webform
+    negate: false
+    context_mapping: {  }
+    webforms: {  }

--- a/config/sync/config_split.config_split.local.yml
+++ b/config/sync/config_split.config_split.local.yml
@@ -1,0 +1,15 @@
+uuid: 5df1761b-7d94-4520-b1c7-93b450f64849
+langcode: en
+status: false
+dependencies: {  }
+id: local
+label: local
+description: 'Settings and configuration for the local development environment.'
+weight: 0
+folder: ../config/splits/local
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true

--- a/config/sync/config_split.config_split.prod.yml
+++ b/config/sync/config_split.config_split.prod.yml
@@ -1,0 +1,16 @@
+uuid: a9047658-cbc6-49be-85dc-df16b03ab7a5
+langcode: en
+status: true
+dependencies: {  }
+id: prod
+label: prod
+description: 'Settings and configuration for the live production site.'
+weight: 0
+folder: ../config/splits/prod
+module: {  }
+theme: {  }
+blacklist:
+  - google_tag.container.main
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -21,6 +21,8 @@ module:
   components: 0
   conditional_fields: 0
   config: 0
+  config_filter: 0
+  config_split: 0
   contact: 0
   content_moderation: 0
   contextual: 0


### PR DESCRIPTION
This PR covers two tickets:

https://forumone.atlassian.net/browse/SLAC22-329
https://forumone.atlassian.net/browse/SLAC22-603

The GTM container in the first ticket is configured via config split for the prod environment in the second ticket.  Testing locally requires a `settings.local.php` file with the following lines included:

```
$config['config_split.config_split.prod']['status'] = TRUE;
$config['config_split.config_split.local']['status'] = FALSE;
```
The GTM container will install by default.  To test the config split, change prod to FALSE and local to TRUE, clear cache and import config.