### PR TITLE
725 - caption spacing adjustment

### DIFF
--- a/web/themes/gesso/templates/content/taxonomy-term--tags--full.html.twig
+++ b/web/themes/gesso/templates/content/taxonomy-term--tags--full.html.twig
@@ -46,11 +46,21 @@
 
 {% if content.field_image|field_value is not empty %}
   {% set image_with_caption %}
-    {% set tooltip %}{% spaceless %}
-      {{- hero_caption -}}
-      {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-      {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
-    {% endspaceless %}{% endset %}
+  {% set tooltip %}
+  {% spaceless %}
+    {{- hero_caption -}}
+    {% if hero_credit|field_value %}
+      {{- hero_credit -}}
+    {% endif %}
+    {% if hero_url %}
+      <p>
+        <a href="{{ hero_url }}">
+          {{ 'Image details'|t }}
+        </a>
+      </p>
+    {% endif %}
+  {% endspaceless %}
+  {% endset %}
 
   {% include '@components/small-captioned-image/small-captioned-image.twig' with {
       image: content.field_image|field_value,

--- a/web/themes/gesso/templates/field/field--media--field-caption--image--tooltip.html.twig
+++ b/web/themes/gesso/templates/field/field--media--field-caption--image--tooltip.html.twig
@@ -41,12 +41,12 @@
 {% for item in items %}
   {% set field_items = field_items|merge([{
     attributes: item.attributes,
-    content: item.content|render|striptags('<em><strong><a><br><p>')
+    content: item.content|render|striptags('<em><strong><a><br>')
   }]) %}
 {% endfor %}
 
 {%- if logged_in -%}
-<div {{ attributes }}>
+  <span {{ attributes }}>
     {{- title_suffix.contextual_links }}
   {%- endif -%}
 
@@ -54,4 +54,6 @@
     {{- item.content|raw -}}
   {%- endfor -%}
 
-  {%- if logged_in %}</div>{% endif -%}
+  {%- if logged_in %}
+  </span>
+{% endif -%}

--- a/web/themes/gesso/templates/field/field--media--field-credit--image--tooltip.html.twig
+++ b/web/themes/gesso/templates/field/field--media--field-credit--image--tooltip.html.twig
@@ -47,9 +47,7 @@
 
 <em {{ attributes.addClass('c-tooltip__credit') }}>
   {{- title_suffix.contextual_links }}
-
-  {%- for item in field_items -%}
+  ({%- for item in field_items -%}
     {{- item.content|raw -}}
-  {%- endfor -%}
-
+  {%- endfor -%})
 </em>

--- a/web/themes/gesso/templates/paragraph/paragraph--article-hero.html.twig
+++ b/web/themes/gesso/templates/paragraph/paragraph--article-hero.html.twig
@@ -39,11 +39,21 @@
  */
 #}
 
-{% set tooltip %}{% spaceless %}
+{% set tooltip %}
+{% spaceless %}
   {{- hero_caption -}}
-  {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-  {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
-{% endspaceless %}{% endset %}
+  {% if hero_credit|field_value %}
+    {{- hero_credit -}}
+  {% endif %}
+  {% if hero_url %}
+    <p>
+      <a href="{{ hero_url }}">
+        {{ 'Image details'|t }}
+      </a>
+    </p>
+  {% endif %}
+{% endspaceless %}
+{% endset %}
 
 {% include '@components/article-hero/article-hero.twig' with {
   hero_image: content.field_image|field_value,

--- a/web/themes/gesso/templates/paragraph/paragraph--image-embed--two-column-hero.html.twig
+++ b/web/themes/gesso/templates/paragraph/paragraph--image-embed--two-column-hero.html.twig
@@ -39,11 +39,21 @@
  */
 #}
 
-{% set tooltip %}{% spaceless %}
+{% set tooltip %}
+{% spaceless %}
   {{- hero_caption -}}
-  {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-  {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
-{% endspaceless %}{% endset %}
+  {% if hero_credit|field_value %}
+    {{- hero_credit -}}
+  {% endif %}
+  {% if hero_url %}
+    <p>
+      <a href="{{ hero_url }}">
+        {{ 'Image details'|t }}
+      </a>
+    </p>
+  {% endif %}
+{% endspaceless %}
+{% endset %}
 
 {% include '@components/small-captioned-image/small-captioned-image.twig' with {
   image: content.field_image|field_value,

--- a/web/themes/gesso/templates/paragraph/paragraph--image-hero.html.twig
+++ b/web/themes/gesso/templates/paragraph/paragraph--image-hero.html.twig
@@ -38,11 +38,21 @@
  * @ingroup themeable
  */
 #}
-{% set tooltip %}{% spaceless %}
+{% set tooltip %}
+{% spaceless %}
   {{- hero_caption -}}
-  {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-  {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
-{% endspaceless %}{% endset %}
+  {% if hero_credit|field_value %}
+    {{- hero_credit -}}
+  {% endif %}
+  {% if hero_url %}
+    <p>
+      <a href="{{ hero_url }}">
+        {{ 'Image details'|t }}
+      </a>
+    </p>
+  {% endif %}
+{% endspaceless %}
+{% endset %}
 
 {% embed '@components/hero-bg-image/hero-bg-image.twig' with {
   'modifier_classes': 'transparent_nav',
@@ -57,4 +67,3 @@
     {{ content.field_lottiefile|field_value }}
   {% endblock %}
 {% endembed %}
-

--- a/web/themes/gesso/templates/paragraph/paragraph--microsite-hero.html.twig
+++ b/web/themes/gesso/templates/paragraph/paragraph--microsite-hero.html.twig
@@ -38,11 +38,21 @@
  * @ingroup themeable
  */
 #}
-{% set tooltip %}{% spaceless %}
+{% set tooltip %}
+{% spaceless %}
   {{- hero_caption -}}
-  {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-  {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
-{% endspaceless %}{% endset %}
+  {% if hero_credit|field_value %}
+    {{- hero_credit -}}
+  {% endif %}
+  {% if hero_url %}
+    <p>
+      <a href="{{ hero_url }}">
+        {{ 'Image details'|t }}
+      </a>
+    </p>
+  {% endif %}
+{% endspaceless %}
+{% endset %}
 
 {% include '@components/microsite-hero/microsite-hero.twig' with {
   'microsite_hero_title': node_title,

--- a/web/themes/gesso/templates/paragraph/paragraph--overlap-image.html.twig
+++ b/web/themes/gesso/templates/paragraph/paragraph--overlap-image.html.twig
@@ -40,13 +40,21 @@
 #}
 
 {% set tooltip %}
-  {{- hero_caption -}}
-  {% if hero_credit|field_value %}<p>{{- hero_credit -}}</p>{% endif %}
-  {% if hero_url %}<p><a href="{{ hero_url }}">{{ 'Image details'|t }}</a></p>{% endif %}
+{{- hero_caption -}}
+{% if hero_credit|field_value %}
+  {{- hero_credit -}}
+{% endif %}
+{% if hero_url %}
+  <p>
+    <a href="{{ hero_url }}">
+      {{ 'Image details'|t }}
+    </a>
+  </p>
+{% endif %}
 {% endset %}
 
 {% set overlap_image %}
-  {% include '@components/overlap-image/overlap-image.twig' with {
+{% include '@components/overlap-image/overlap-image.twig' with {
     'image_caption': tooltip,
     'overlap_image_content': content.field_paragraph|field_value,
     'icon_content': content.field_lottiefile|field_value,
@@ -55,7 +63,9 @@
   } %}
 {% endset %}
 
-{% if is_nested %}{{ overlap_image }}{% else %}
+{% if is_nested %}
+  {{ overlap_image }}
+{% else %}
   {% include '@layouts/section/section.twig' with {
     section_content: overlap_image,
     modifier_classes: 'l-section--no-padding',


### PR DESCRIPTION
Per Jenny's request, this moves the caption & credit onto one line in image tooltips. (The "image details" link, if present, is still on a separate line.) 

Several examples here - https://integration-slac-w6-d9.pantheonsite.io/research/x-ray-and-ultrafast-science
(The hero caption breaks onto separate lines, but this is a coincidence based on text length.)