### PR TITLE
722 - adjust person cards

### DIFF
--- a/web/themes/gesso/source/03-components/card/_card.scss
+++ b/web/themes/gesso/source/03-components/card/_card.scss
@@ -345,6 +345,12 @@ $card-padding: rem(gesso-spacing(4));
     aspect-ratio: 1/1;
   }
 
+  .c-view--search & {
+    .c-card__media {
+      aspect-ratio: 387 / 246;
+    }
+  }
+
   .c-figure {
     width: 100%;
   }


### PR DESCRIPTION
Request was to make the aspect ratio match other search cards. No change to the cards as viewed outside of search (leadership listing pages etc)