### PR TITLE
SLAC22-546 - adjustments to floating image embed

### DIFF
--- a/web/themes/gesso/source/03-components/floated-image/_floated-image.scss
+++ b/web/themes/gesso/source/03-components/floated-image/_floated-image.scss
@@ -1,24 +1,30 @@
 @use '00-config' as *;
 
 .c-floated-image {
-  --float-image-offset: -120px;
+  .l-section__content {
+    // stylelint-disable
+    container-type: inline-size;
+  }
 
   img {
     width: 100%;
   }
 
   .c-floated-image__figure {
-    max-width: calc(40% - var(--float-image-offset)) !important;
+    max-width: 40cqw !important;
 
     &.u-align-left {
-      margin-left: var(--float-image-offset);
+      margin-left: calc(-50cqw + 50%);
     }
 
     &.u-align-right {
-      margin-right: var(--float-image-offset);
+      margin-right: calc(-50cqw + 50%);
     }
+  }
+  @include breakpoint-max(gesso-breakpoint(tablet-lg)) {
+    margin: 1em auto;
 
-    @include breakpoint-max(gesso-breakpoint(tablet-lg)) {
+    .c-floated-image__figure {
       &,
       &.u-align-left,
       &.u-align-right {

--- a/web/themes/gesso/source/03-components/floated-image/_floated-image.scss
+++ b/web/themes/gesso/source/03-components/floated-image/_floated-image.scss
@@ -11,6 +11,7 @@
   }
 
   .c-floated-image__figure {
+    margin-top: 0.5em;
     max-width: 40cqw !important;
 
     &.u-align-left {
@@ -25,6 +26,8 @@
     margin: 1em auto;
 
     .c-floated-image__figure {
+      margin-top: 0;
+
       &,
       &.u-align-left,
       &.u-align-right {


### PR DESCRIPTION
https://integration-slac-w6-d9.pantheonsite.io/node/5512

The image is now set to be 40% of the wider content constrain, and pushed all the way to the right or left edge of it.