### PR TITLE
fix regression in promo box title size (slac22-720)

### DIFF
--- a/web/themes/gesso/source/03-components/promo-box/_promo-box.scss
+++ b/web/themes/gesso/source/03-components/promo-box/_promo-box.scss
@@ -60,6 +60,7 @@
 }
 
 .c-promo-box__title {
+  @include responsive-font-size(6);
   max-width: rem(280px);
 }
 


### PR DESCRIPTION
Meant to lock down this font size when we updated the global styles.